### PR TITLE
Make random instance generator seed not fixed

### DIFF
--- a/generate-random-data.pi
+++ b/generate-random-data.pi
@@ -1,6 +1,11 @@
 import io.
 
-main =>    
+main() =>
+    main([random2()]).
+
+main([Seed]) =>    
+    _ = random(to_int(Seed)),
+    
     NumItems = 15,
     Capacity = 100,
     MinValue = 1,


### PR DESCRIPTION
Currently running `generate-random-data.pi` always generates the same instance. This PR changes it to: Running with no arguments = random seed
Running with one argument = use that argument as seed

I know this won't transfer to already created student repositories but maybe not everyone made their repo yet, and it could be useful if these homeworks are reused next year.